### PR TITLE
fix: typescript test fix

### DIFF
--- a/sprint_2/check_typescript.js
+++ b/sprint_2/check_typescript.js
@@ -10,7 +10,7 @@ const package = () => {
     return JSON.parse(fs.readFileSync('./package.json', 'utf-8').toString());
 }
 
-if ((package().dependencies.hasOwnProperty('typescript'))) {
+if ((package().dependencies?.hasOwnProperty('typescript'))) {
 	redLog('typescript should be only in devDependencies, not in dependencies')
 	process.exit(1)
 }


### PR DESCRIPTION
Если в проекте вообще нет обычных dependencies, то этот тест падает, потому что `package().dependencies === undefined`

Эта штука должна помочь, если в окружении тестов поддерживается optional chaining.