### PR TITLE
exclude build folder from check

### DIFF
--- a/sprint_2/check_stylelint.js
+++ b/sprint_2/check_stylelint.js
@@ -19,7 +19,7 @@ function getAllFiles(dirPath, arrayOfFiles = []) {
   const files = fs.readdirSync(dirPath);
 
   files
-    .filter((file) => file !== 'node_modules' && file !== 'dist')
+    .filter((file) => file !== 'node_modules' && file !== 'dist' && file !== 'build')
     .forEach(function(file) {
     if (fs.statSync(dirPath + "/" + file).isDirectory()) {
       arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles)


### PR DESCRIPTION
Привет!
При запуске команды StyleLint директория `build` не исключается из проверки.
Т.к сборка запускается перед проверкой линтинга, в рабочей директории создается новая директория, которая может быть названа build, что вполне допустимо. В результате в проверку линтинга могут попасть исходники с расширением `CSS` в дополнение к файлам `SASS` `PostSCSS` и тп. Далее тест падает